### PR TITLE
PROD-913: Allow longer TTLs on impersonation tokens when allowed

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,14 @@ permissions listed below. The following steps assume you have
     $ gcloud projects add-iam-policy-binding "${GOOGLE_CLOUD_PROJECT}" \
         --member "serviceAccount:vault-tester@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com" \
         --role "roles/owner"
+
+    $ gcloud projects add-iam-policy-binding "${GOOGLE_CLOUD_PROJECT}" \
+        --member "serviceAccount:vault-tester@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com" \
+        --role "roles/iam.serviceAccountTokenCreator"
+
+    $ gcloud projects add-iam-policy-binding "${GOOGLE_CLOUD_PROJECT}" \
+        --member "serviceAccount:vault-tester@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com" \
+        --role "roles/iam.serviceAccountKeyAdmin"
     ```
 
     Note: these are overly broad permissions because the account needs a
@@ -168,25 +176,25 @@ permissions listed below. The following steps assume you have
     **strongly recommended** that you have a dedicated project for running
     tests.
 
-1. Download the service account key file to local disk:
+2. Download the service account key file to local disk:
 
     ```text
     $ gcloud iam service-accounts keys create vault-tester.json \
         --iam-account "vault-tester@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"
     ```
 
-1. Export the credentials to an environment variable. You can set the env variable to either 
+3. Export the credentials to an environment variable. You can set the env variable to either
    the path or the JSON itself, i.e.
-   
+
     ```text
     $ export GOOGLE_CREDENTIALS="path/to/vault-tester.json"
     ```
-    
+
     ```text
     $ export GOOGLE_CREDENTIALS="$(cat path/to/vault-tester.json)"
     ```
 
-1. Run the acceptance tests:
+4. Run the acceptance tests:
 
     ```text
     $ make test-acc

--- a/plugin/backend_test.go
+++ b/plugin/backend_test.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/api/cloudresourcemanager/v1"
 	"google.golang.org/api/iam/v1"
 	"google.golang.org/api/option"
+	"google.golang.org/api/orgpolicy/v2"
 )
 
 const (
@@ -47,11 +48,12 @@ type testData struct {
 	Project    string
 	HttpClient *http.Client
 	IamAdmin   *iam.Service
+	OrgAdmin   *orgpolicy.Service
 }
 
-func setupTest(t *testing.T, ttl, maxTTL string) *testData {
+func setupTestCredentials(t *testing.T) *testData {
 	proj := util.GetTestProject(t)
-	credsJson, creds := util.GetTestCredentials(t)
+	_, creds := util.GetTestCredentials(t)
 	httpC, err := gcputil.GetHttpClient(creds, iam.CloudPlatformScope)
 	if err != nil {
 		t.Fatal(err)
@@ -62,21 +64,39 @@ func setupTest(t *testing.T, ttl, maxTTL string) *testData {
 		t.Fatal(err)
 	}
 
-	b, reqStorage := getTestBackend(t)
+	orgAdmin, err := orgpolicy.NewService(context.Background(), option.WithHTTPClient(httpC))
+	if err != nil {
+		t.Fatal(err)
+	}
 
+	return &testData{
+		B:          nil,
+		S:          nil,
+		Project:    proj,
+		HttpClient: httpC,
+		IamAdmin:   iamAdmin,
+		OrgAdmin:   orgAdmin,
+	}
+}
+
+func setupTestBackend(t *testing.T, td *testData, ttl, maxTTL string) {
+
+	b, reqStorage := getTestBackend(t)
+	td.B = b
+	td.S = reqStorage
+	credsJson, _ := util.GetTestCredentials(t)
 	testConfigUpdate(t, b, reqStorage, map[string]interface{}{
 		"credentials": credsJson,
 		"ttl":         ttl,
 		"max_ttl":     maxTTL,
 	})
 
-	return &testData{
-		B:          b,
-		S:          reqStorage,
-		Project:    proj,
-		HttpClient: httpC,
-		IamAdmin:   iamAdmin,
-	}
+}
+
+func setupTest(t *testing.T, ttl, maxTTL string) *testData {
+	td := setupTestCredentials(t)
+	setupTestBackend(t, td, ttl, maxTTL)
+	return td
 }
 
 func cleanup(t *testing.T, td *testData, saDisplayName string, roles util.StringSet) {

--- a/plugin/impersonated_account.go
+++ b/plugin/impersonated_account.go
@@ -34,6 +34,7 @@ type ImpersonatedAccount struct {
 	gcputil.ServiceAccountId
 
 	TokenScopes []string
+	Ttl         int
 }
 
 func (a *ImpersonatedAccount) validate() error {
@@ -97,6 +98,7 @@ func (b *backend) createImpersonatedAccount(ctx context.Context, req *logical.Re
 		Name:             input.name,
 		ServiceAccountId: acctId,
 		TokenScopes:      input.scopes,
+		Ttl:              input.ttl,
 	}
 
 	// Save to storage.
@@ -125,6 +127,12 @@ func (b *backend) updateImpersonatedAccount(ctx context.Context, req *logical.Re
 	if !strutil.EquivalentSlices(updateInput.scopes, a.TokenScopes) {
 		b.Logger().Debug("detected scopes change, updating scopes for impersonated account")
 		a.TokenScopes = updateInput.scopes
+		madeChange = true
+	}
+
+	if updateInput.ttl != a.Ttl {
+		b.Logger().Debug("detected ttl change, updating ttl for impersonated account")
+		a.Ttl = updateInput.ttl
 		madeChange = true
 	}
 

--- a/plugin/impersonated_account_field_data_utils.go
+++ b/plugin/impersonated_account_field_data_utils.go
@@ -13,6 +13,7 @@ type impersonatedAccountInputParams struct {
 	serviceAccountEmail string
 
 	scopes []string
+	ttl    int
 }
 
 // parseOkInputServiceAccountEmail checks that when creating a static acocunt, a service account

--- a/plugin/path_impersonated_account.go
+++ b/plugin/path_impersonated_account.go
@@ -31,6 +31,10 @@ func pathImpersonatedAccount(b *backend) *framework.Path {
 				Type:        framework.TypeCommaStringSlice,
 				Description: "List of OAuth scopes to assign to access tokens generated under this account.",
 			},
+			"ttl": {
+				Type:        framework.TypeDurationSecond,
+				Description: "Lifetime of the token for the impersonated account.",
+			},
 		},
 		ExistenceCheck: b.pathImpersonatedAccountExistenceCheck,
 		Operations: map[logical.Operation]framework.OperationHandler{
@@ -98,6 +102,7 @@ func (b *backend) pathImpersonatedAccountRead(ctx context.Context, req *logical.
 		"service_account_project": acct.Project,
 		"service_account_email":   acct.EmailOrId,
 		"token_scopes":            acct.TokenScopes,
+		"ttl":                     acct.Ttl,
 	}
 
 	return &logical.Response{
@@ -178,6 +183,7 @@ func (b *backend) pathImpersonatedAccountUpdate(ctx context.Context, req *logica
 		project:             acct.Project,
 		serviceAccountEmail: acct.EmailOrId,
 		scopes:              acct.TokenScopes,
+		ttl:                 acct.Ttl,
 	}
 
 	updateInput, warnings, err := b.parseImpersonateInformation(initialInput, d)
@@ -233,6 +239,11 @@ func (b *backend) parseImpersonateInformation(prevValues *impersonatedAccountInp
 		return nil, nil, err
 	} else if len(ws) > 0 {
 		warnings = append(warnings, ws...)
+	}
+
+	ttl, ok := d.GetOk("ttl")
+	if ok {
+		input.ttl = ttl.(int)
 	}
 
 	return input, warnings, nil

--- a/plugin/path_impersonated_account_secrets.go
+++ b/plugin/path_impersonated_account_secrets.go
@@ -3,7 +3,6 @@ package gcpsecrets
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/vault/sdk/framework"
@@ -28,18 +27,6 @@ func pathImpersonatedAccountSecretAccessToken(b *backend) *framework.Path {
 		HelpSynopsis:    pathTokenHelpSyn,
 		HelpDescription: pathTokenHelpDesc,
 	}
-}
-
-func isOrgPolicyConstraintMissingError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	if strings.Contains(err.Error(), "constraints/iam.allowServiceAccountCredentialLifetimeExtension") {
-		return true
-	}
-
-	return false
 }
 
 func (b *backend) pathImpersonatedAccountAccessToken(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {


### PR DESCRIPTION
Proposed changes for allowing TTLs on Impersonated Accounts to exceed 1 hour.  

- I have tested this as much as I can right now in the `datadog-sandbox` account.  
-  On https://console.cloud.google.com/iam-admin/orgpolicies/iam-allowServiceAccountCredentialLifetimeExtension?orgonly=true&project=datadog-sandbox&supportedpurview=organizationId the `constraints/iam.allowServiceAccountCredentialLifetimeExtension` constraint is inherited 
- I need to figure out how to go set that to `ALLOW` to test further
