### PR TITLE
add logging and change error messages

### DIFF
--- a/plugin/impersonated_account.go
+++ b/plugin/impersonated_account.go
@@ -137,7 +137,7 @@ func (b *backend) updateImpersonatedAccount(ctx context.Context, req *logical.Re
 	}
 
 	if !madeChange {
-		return []string{"no changes to bindings or token_scopes detected, no update needed"}, nil
+		return []string{"no changes to token_scopes or ttl detected, no update needed"}, nil
 	}
 
 	if err := a.save(ctx, req.Storage); err != nil {

--- a/plugin/path_impersonated_account_secrets.go
+++ b/plugin/path_impersonated_account_secrets.go
@@ -52,9 +52,13 @@ func (b *backend) pathImpersonatedAccountAccessToken(ctx context.Context, req *l
 
 	acctTtl := time.Duration(acct.Ttl) * time.Second
 	if acctTtl > config.MaxTTL {
+		b.Logger().Debug("impersonated account %q ttl of %s is greater than backend max ttl of %s so clamping ttl to max", acctName, acctTtl, config.MaxTTL)
 		acctTtl = config.MaxTTL
 	} else if acctTtl == 0 {
+		b.Logger().Debug("impersonated account %q ttl not configured so using backend default ttl of %s", acctName, config.TTL)
 		acctTtl = config.TTL
+	} else {
+		b.Logger().Debug("impersonated account %q ttl of %s being used", acctName, acctTtl)
 	}
 
 	tokenSource, err := impersonate.CredentialsTokenSource(ctx, impersonate.CredentialsConfig{


### PR DESCRIPTION
This just changes one of the warning messages to be more correct and adds debug logging so we can figure out what is going on in our environment that is preventing the desired TTLs from being achieved.